### PR TITLE
fix: improve character card image positioning and hover behavior

### DIFF
--- a/src/ui/designSystem/molecules/CharacterCard/CharacterCard.module.scss
+++ b/src/ui/designSystem/molecules/CharacterCard/CharacterCard.module.scss
@@ -29,6 +29,7 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
+  object-position: center top; // Show top of image (face) instead of center
   display: block;
 }
 

--- a/src/ui/pages/FavoritesPage/FavoritesPage.module.scss
+++ b/src/ui/pages/FavoritesPage/FavoritesPage.module.scss
@@ -96,6 +96,7 @@
     width: 100%;
     height: 100%;
     object-fit: cover;
+    object-position: center top; // Show top of image (face) instead of center
     display: block;
     transform: none;
     transition: none;
@@ -113,25 +114,25 @@
 }
 
 .cardAccent {
-  width: 100%;
-  height: 5.37857px;
-  background-color: #EC1D24;
-  flex-shrink: 0;
-  @include safe-animation(all $duration-base $ease-out);
-}
-
-.cardLink:hover .cardAccent {
+  // ALWAYS absolutely positioned to prevent layout shift on hover
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
-  bottom: 0;
-  height: 100%;
+  width: 100%;
+  height: 5.37857px;
+  background-color: #EC1D24;
   z-index: 0;
+  @include safe-animation(height $duration-base $ease-out);
+}
+
+.cardLink:hover .cardAccent {
+  height: 100%; // Expands from 5.38px to full footer height
 }
 
 .cardContent {
-  padding: 12px 8px;
+  // Add top padding to account for absolutely positioned accent line (5.38px)
+  padding: 17.37857px 8px 12px 8px; // top includes accent height + original padding
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -141,11 +142,11 @@
   flex: 1;
   
   @include mobile {
-    padding: 10px 8px;
+    padding: 15.37857px 8px 10px 8px; // top includes accent height + original padding
   }
   
   @include md {
-    padding: 14px 8px;
+    padding: 19.37857px 8px 14px 8px; // top includes accent height + original padding
   }
 }
 

--- a/src/ui/pages/ListPage/ListPage.module.scss
+++ b/src/ui/pages/ListPage/ListPage.module.scss
@@ -118,6 +118,7 @@
     width: 100%;
     height: 100%;
     object-fit: cover;
+    object-position: center top; // Show top of image (face) instead of center
     display: block;
     // Prevent image movement on hover
     transform: none;
@@ -139,26 +140,26 @@
 
 // Red accent line ABOVE the name (not border-bottom)
 .cardAccent {
-  width: 100%;
-  height: 5.37857px; // Exact from SVG mockup (5.38px rounded)
-  background-color: #EC1D24; // Marvel red
-  flex-shrink: 0; // Don't shrink
-  @include safe-animation(all $duration-base $ease-out);
-}
-
-// Hover effect: red line expands downward to cover entire footer background
-.cardLink:hover .cardAccent {
+  // ALWAYS absolutely positioned to prevent layout shift on hover
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
-  bottom: 0;
-  height: 100%; // Expands from 5.38px to full footer height
+  width: 100%;
+  height: 5.37857px; // Exact from SVG mockup (5.38px rounded)
+  background-color: #EC1D24; // Marvel red
   z-index: 0;
+  @include safe-animation(height $duration-base $ease-out);
+}
+
+// Hover effect: red line expands downward to cover entire footer background
+.cardLink:hover .cardAccent {
+  height: 100%; // Expands from 5.38px to full footer height
 }
 
 .cardContent {
-  padding: 12px 8px;
+  // Add top padding to account for absolutely positioned accent line (5.38px)
+  padding: 17.37857px 8px 12px 8px; // top includes accent height + original padding
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -168,11 +169,11 @@
   flex: 1; // Takes remaining space
   
   @include mobile {
-    padding: 10px 8px;
+    padding: 15.37857px 8px 10px 8px; // top includes accent height + original padding
   }
   
   @include md {
-    padding: 14px 8px;
+    padding: 19.37857px 8px 14px 8px; // top includes accent height + original padding
   }
 }
 


### PR DESCRIPTION
- Add object-position: center top to show character faces instead of torsos
- Fix footer layout shift on hover by making accent line always absolute
- Remove padding-top from cardFooter to eliminate black space above red line
- Adjust cardContent padding to account for absolutely positioned accent line
- Maintain smooth red background expansion on hover with no layout shift